### PR TITLE
Add ability to refresh available flair for linked TagPro account.

### DIFF
--- a/tagpro_flair_bot/urls.py
+++ b/tagpro_flair_bot/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.conf.urls.static import static
 
-from views import auth_tagpro, deauth_tagpro, set_flair, HomeView
+from views import auth_tagpro, deauth_tagpro, set_flair, refresh_flair, HomeView
 
 from django.contrib import admin
 admin.autodiscover()
@@ -12,6 +12,7 @@ urlpatterns = patterns('',
     url(r'^tp_auth/$', auth_tagpro, name="auth_tagpro"),
     url(r'^tp_logout/$', deauth_tagpro, name="deauth_tagpro"),
     url(r'^set_flair/$', set_flair, name="set_flair"),
+    url(r'^refresh_flair/$', refresh_flair, name="refresh_flair"),
     url('', include('social.apps.django_app.urls', namespace='social')),
 )
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -43,7 +43,10 @@
 <h2>Step 4</h2>
 <p><em>Choose your flair</em></p>
 {% if request.session.tp_authenticated %}
-        
+    <form action="{% url 'refresh_flair' %}" method="post">
+        {% csrf_token %}
+        <input type="submit" value="Refresh Available Flair" />
+    </form>
     {% if request.session.available_flair %}
     <form action="{% url 'set_flair' %}" method="post" id="flair-form">
     {% csrf_token %}


### PR DESCRIPTION
This allows a Reddit and TagPro-authenticated user to refresh the flair available for selection. This makes setting flair a little less of a burden as long as the session cookie is still set for the website, since selecting newly-acquired flair wouldn't require going through the authentication process again.

I did not incorporate any rate-limiting, but it can be added if you think it is necessary.
